### PR TITLE
Rework of ROC metric and curves in multi-classification

### DIFF
--- a/hipe4ml/analysis_utils.py
+++ b/hipe4ml/analysis_utils.py
@@ -1,5 +1,6 @@
-""" Module containing the analysis utils.
-    """
+"""
+Module containing the analysis utils.
+"""
 
 import numpy as np
 from scipy.interpolate import InterpolatedUnivariateSpline
@@ -8,7 +9,7 @@ from sklearn.preprocessing import label_binarize
 
 def bdt_efficiency_array(y_truth, y_score, n_points=50, keep_lower=False):
     """
-    Calculate the BDT efficiency as a function of the score
+    Calculate the model efficiency as a function of the score
     threshold. The candidates for each class should be labeled
     with 0, ..., N. In case of binary classification, 0 should
     correspond to the background while 1 to the signal
@@ -35,13 +36,11 @@ def bdt_efficiency_array(y_truth, y_score, n_points=50, keep_lower=False):
     Output
     ------------------------------------------------
     efficiency: numpy array
-        Efficiency array as a function of the threshold value
+        Efficiency as a function of the threshold value
         Numpy array of numpy arrays in case of multi-classification
 
     threshold: numpy array
-        Threshold values array
-
-
+        Threshold values
     """
     operator = np.greater
     if keep_lower:
@@ -109,8 +108,6 @@ def score_from_efficiency_array(y_truth, y_score, efficiency_selected, keep_lowe
     -----------------------------------------------
     score_array: numpy array
         Score array corresponding to efficiency_selected
-
-
     """
     score_list = []
     eff, score = bdt_efficiency_array(y_truth, y_score, n_points=1000, keep_lower=keep_lower)

--- a/hipe4ml/analysis_utils.py
+++ b/hipe4ml/analysis_utils.py
@@ -3,8 +3,6 @@
 
 import numpy as np
 from scipy.interpolate import InterpolatedUnivariateSpline
-from sklearn.metrics import roc_auc_score
-from sklearn.model_selection import KFold
 from sklearn.preprocessing import label_binarize
 
 
@@ -121,50 +119,3 @@ def score_from_efficiency_array(y_truth, y_score, efficiency_selected, keep_lowe
         score_list.append(interp.roots()[0])
     score_array = np.array(score_list)
     return score_array
-
-
-def cross_val_roc_score_multiclass(model, training_df, y_training, n_classes, n_fold):
-    """
-    Evaluate a score using the roc auc metric by cross validation for multiclass
-    classifiers
-
-    Input
-    ------------------------------------------------
-    model : xgboost or sklearn multiclass model
-
-    df_training: Pandas Dataframe
-        Training set dataframe
-
-    y_training: array
-        Training set labels. The candidates for each
-        class should be labeled with 0, ..., N.
-
-    n_classes: int
-        Number of classes: should be greater than two. Otherwise
-        use the standard cross_val_score(sklearn) implementation
-
-    nfold: int
-        Number of folds to calculate the cross
-        validation error
-
-    Output
-    ------------------------------------------------
-    mean: int
-        Average of the scores evaluated in the k-different folds
-
-
-    """
-    scores = []
-    kfold = KFold(n_splits=n_fold, shuffle=True, random_state=42)
-    for index in kfold.split(training_df):
-        x_train = training_df.iloc[index[0]]
-        y_train = y_training[index[0]]
-        x_test = training_df.iloc[index[1]]
-        y_test = y_training[index[1]]
-        model.fit(x_train, y_train)
-        y_score = model.predict_proba(x_test)
-        y_test_multi = label_binarize(y_test, classes=range(n_classes))
-        score = roc_auc_score(y_test_multi, y_score, average='micro')
-        scores.append(score)
-    mean = np.mean(scores)
-    return mean

--- a/hipe4ml/model_handler.py
+++ b/hipe4ml/model_handler.py
@@ -412,3 +412,4 @@ class ModelHandler:
         self.training_columns = loaded_model.get_training_columns()
         self.model_params = loaded_model.get_model_params()
         self.model_string = loaded_model.get_model_module()
+        self.multiclass = loaded_model.get_multiclass()

--- a/hipe4ml/model_handler.py
+++ b/hipe4ml/model_handler.py
@@ -30,9 +30,8 @@ class ModelHandler:
         example (XGBoost): max_depth, learning_rate,
         n_estimators, gamma, min_child_weight, ...
 
-     multiclass: bool
+    multiclass: bool
         Whether it is a multi-classification problem
-
     """
 
     def __init__(self, input_model=None, training_columns=None, model_params=None, multiclass=False):
@@ -57,7 +56,6 @@ class ModelHandler:
             Model hyper-parameter values. For
             example (XGBoost): max_depth, learning_rate,
             n_estimators, gamma, min_child_weight, ...
-
         """
         self.model_params = model_params
         self.model.set_params(**model_params)
@@ -72,7 +70,6 @@ class ModelHandler:
             Model hyper-parameter values. For
             example (XGBoost): max_depth, learning_rate,
             n_estimators, gamma, min_child_weight, ...
-
         """
         return self.model.get_params()
 
@@ -85,7 +82,6 @@ class ModelHandler:
         training_columns: list
             Contains the name of the features used for the training.
             Example: ['dEdx', 'pT', 'ct']
-
         """
         self.training_columns = training_columns
 
@@ -98,7 +94,6 @@ class ModelHandler:
         list
             Contains the name of the features used for the training.
             Example: ['dEdx', 'pT', 'ct']
-
         """
 
         return self.training_columns
@@ -111,7 +106,6 @@ class ModelHandler:
         ------------------------------------
         multiclass: bool
             Whether it is a multi-classification problem
-
         """
         self.multiclass = multiclass
 
@@ -123,7 +117,6 @@ class ModelHandler:
         ------------------------------------
         bool
             Whether it is a multi-classification problem
-
         """
         return self.multiclass
 
@@ -133,7 +126,7 @@ class ModelHandler:
 
         Output
         ---------------------------
-        sklearn_or_xgboost_model
+        sklearn or XGBoost model
         """
         return self.model
 
@@ -160,7 +153,6 @@ class ModelHandler:
 
         y_train: array-like, sparse matrix
             Target data
-
         """
         if self.training_columns is not None:
             self.model.fit(x_train[self.training_columns], y_train)
@@ -184,9 +176,8 @@ class ModelHandler:
 
         Output
         ---------------------------------------
-        numpy_array
-            Model prediction
-
+        pred: numpy_array
+            Model predictions
         """
         if self.training_columns is not None:
             x_test = x_test[self.training_columns]
@@ -244,11 +235,10 @@ class ModelHandler:
 
     def evaluate_hyperparams(self, data, opt_params, scoring, nfold=5, njobs=None):
         """
-        Calculate for a set of hyperparams the cross val score
+        Calculate the cross-validation score for a set of hyper-parameters
 
         Input
         ------------------------------------------
-
         data: list
             Contains respectively: training
             set dataframe, training label array,
@@ -278,8 +268,6 @@ class ModelHandler:
         float
             Cross validation score evaluated using
             the ROC AUC metrics
-
-
         """
         opt_params = self.cast_model_params(opt_params)
         params = {**self.model_params, **opt_params}
@@ -292,11 +280,11 @@ class ModelHandler:
     def optimize_params_bayes(self, data, hyperparams_ranges, scoring, nfold=5, init_points=5,
                               n_iter=5, njobs=None):
         """
-        Perform Bayesian optimization
+        Perform Bayesian optimization and update the model hyper-parameters
+        with the best ones
 
         Input
         ------------------------------------------------------
-
         data: list
             Contains respectively: training
             set dataframe, training label array,
@@ -335,12 +323,6 @@ class ModelHandler:
         njobs: int or None
             Number of CPUs to perform computation used in the score evaluation
             with cross-validation. Set to -1 to use all CPUs
-
-        Output
-        ---------------------------------------------------------
-        dict
-            Contains the optimized parameters
-
         """
         # just an helper function
         def hyperparams_crossvalidation(**kwargs):
@@ -367,7 +349,6 @@ class ModelHandler:
 
         Input
         -----------------------------------------------------
-
         params: dict
             Hyperparameter values. For
             example: max_depth, learning_rate,
@@ -376,10 +357,8 @@ class ModelHandler:
 
         Output
         -----------------------------------------------------
-
-        dict
+        params: dict
             Hyperparameter values updated
-
         """
         for key in params.keys():
             if isinstance(self.model.get_params()[key], int):
@@ -416,9 +395,7 @@ class ModelHandler:
         -----------------------------------------------------
         filename: str
             Name of the file in which the model is saved
-
         """
-
         pickle.dump(self, open(filename, "wb"))
 
     def load_model_handler(self, filename):

--- a/hipe4ml/model_handler.py
+++ b/hipe4ml/model_handler.py
@@ -29,16 +29,12 @@ class ModelHandler:
         Model hyper-parameter values. For
         example (XGBoost): max_depth, learning_rate,
         n_estimators, gamma, min_child_weight, ...
-
-    multiclass: bool
-        Whether it is a multi-classification problem
     """
 
-    def __init__(self, input_model=None, training_columns=None, model_params=None, multiclass=False):
+    def __init__(self, input_model=None, training_columns=None, model_params=None):
         self.model = input_model
         self.training_columns = training_columns
         self.model_params = model_params
-        self.multiclass = multiclass
 
         if self.model is not None:
             self.model_string = inspect.getmodule(self.model).__name__.partition('.')[0]
@@ -97,28 +93,6 @@ class ModelHandler:
         """
 
         return self.training_columns
-
-    def set_multiclass(self, multiclass=True):
-        """
-        Set the multiclass flag
-
-        Input
-        ------------------------------------
-        multiclass: bool
-            Whether it is a multi-classification problem
-        """
-        self.multiclass = multiclass
-
-    def get_multiclass(self):
-        """
-        Get the multiclass flag
-
-        Output
-        ------------------------------------
-        bool
-            Whether it is a multi-classification problem
-        """
-        return self.multiclass
 
     def get_original_model(self):
         """
@@ -188,10 +162,11 @@ class ModelHandler:
             if self.model_string == 'sklearn':
                 pred = self.model.decision_function(x_test).ravel()
         else:
-            if self.multiclass:
-                pred = self.model.predict_proba(x_test)
-            else:
-                pred = self.model.predict_proba(x_test)[:, 1]
+            pred = self.model.predict_proba(x_test)
+            # in case of binary classification return only the scores of
+            # the signal class
+            if pred.shape[1] <= 2:
+                pred = pred[:, 1]
 
         return pred
 
@@ -412,4 +387,3 @@ class ModelHandler:
         self.training_columns = loaded_model.get_training_columns()
         self.model_params = loaded_model.get_model_params()
         self.model_string = loaded_model.get_model_module()
-        self.multiclass = loaded_model.get_multiclass()

--- a/hipe4ml/model_handler.py
+++ b/hipe4ml/model_handler.py
@@ -207,7 +207,7 @@ class ModelHandler:
 
         multi_class_opt: string
             Option to compute ROC AUC scores used only in case of multi-classification.
-            The one-vs-one 'ovo' and one-vs-rest 'ovr' approaches are available.
+            The one-vs-one 'ovo' and one-vs-rest 'ovr' approaches are available
         """
 
         # get number of classes
@@ -225,7 +225,7 @@ class ModelHandler:
             roc_score = roc_auc_score(data[3], y_pred)
         else:
             y_pred = self.predict(data[2], output_margin=False, multiclass=True)
-            roc_score = roc_auc_score(data[3], y_pred, average, None, None, multi_class_opt)
+            roc_score = roc_auc_score(data[3], y_pred, average=average, multi_class=multi_class_opt)
 
         print('Testing the model: Done!')
 

--- a/hipe4ml/plot_utils.py
+++ b/hipe4ml/plot_utils.py
@@ -10,7 +10,7 @@ from sklearn.metrics import (auc, average_precision_score,
 from sklearn.preprocessing import label_binarize
 
 
-def _plot_distr(df_train, df_test, lims, bins, label, color, kwds):
+def _plot_output(df_train, df_test, lims, bins, label, color, kwds):
     """
     Utility function for plot_output_train_test
     """
@@ -101,7 +101,7 @@ def plot_output_train_test(model, data, bins=80, output_margin=True, labels=None
         colors = ['b', 'r']
         res.append(plt.figure())
         for i_class, (label, color) in enumerate(zip(labels, colors)):
-            _plot_distr(prediction[i_class], prediction[i_class+2], low_high, bins, label, color, kwds)
+            _plot_output(prediction[i_class], prediction[i_class+2], low_high, bins, label, color, kwds)
         if logscale:
             plt.yscale('log')
         plt.xlabel('BDT output', fontsize=13, ha='right', position=(1, 20))
@@ -116,8 +116,8 @@ def plot_output_train_test(model, data, bins=80, output_margin=True, labels=None
         for output, out_label in zip(class_labels, labels):
             res.append(plt.figure())
             for i_class, (label, color) in enumerate(zip(labels, colors)):
-                _plot_distr(prediction[i_class][:, output], prediction[i_class+n_classes][:, output], low_high, bins,
-                            label, color, kwds)
+                _plot_output(prediction[i_class][:, output], prediction[i_class+n_classes][:, output], low_high, bins,
+                             label, color, kwds)
             if logscale:
                 plt.yscale('log')
             plt.xlabel(f'BDT output for {out_label}', fontsize=13, ha='right', position=(1, 20))

--- a/hipe4ml/plot_utils.py
+++ b/hipe4ml/plot_utils.py
@@ -33,8 +33,7 @@ def _plot_output(df_train, df_test, lims, bins, label, color, kwds):
     plt.errorbar(center, hist, yerr=err, fmt='o', c=color, label=f'{label} pdf Test Set')
 
 
-def plot_output_train_test(model, data, bins=80, output_margin=True, labels=None, multiclass=False,
-                           logscale=False, **kwds):
+def plot_output_train_test(model, data, bins=80, output_margin=True, labels=None, logscale=False, **kwds):
     """
     Plot the BDT output distributions for each class and output
     both for training and test set.
@@ -67,10 +66,6 @@ def plot_output_train_test(model, data, bins=80, output_margin=True, labels=None
         Contains the labels to be displayed in the legend
         If None the labels are class1, class2, ..., classN
 
-    multiclass: bool
-        Set to true (mandatory) when using output_margin = False in a
-        multi-class problem to have the probability of each class
-
     logscale: bool
         Whether to plot the y axis in log scale
 
@@ -90,7 +85,7 @@ def plot_output_train_test(model, data, bins=80, output_margin=True, labels=None
     prediction = []
     for xxx, yyy in ((data[0], data[1]), (data[2], data[3])):
         for class_lab in class_labels:
-            prediction.append(model.predict(xxx[yyy == class_lab], output_margin, multiclass))
+            prediction.append(model.predict(xxx[yyy == class_lab], output_margin))
 
     low = min(np.min(d) for d in prediction)
     high = max(np.max(d) for d in prediction)

--- a/hipe4ml/plot_utils.py
+++ b/hipe4ml/plot_utils.py
@@ -1,6 +1,9 @@
-""" Module containing the plot utils. Each function returns a matplotlib object
 """
+Module containing the plot utils. Each function returns a matplotlib object
+"""
+
 from itertools import combinations
+
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
@@ -35,7 +38,7 @@ def _plot_output(df_train, df_test, lims, bins, label, color, kwds):
 
 def plot_output_train_test(model, data, bins=80, output_margin=True, labels=None, logscale=False, **kwds):
     """
-    Plot the BDT output distributions for each class and output
+    Plot the model output distributions for each class and output
     both for training and test set.
 
     Input
@@ -74,10 +77,8 @@ def plot_output_train_test(model, data, bins=80, output_margin=True, labels=None
 
     Output
     ----------------------------------------
-    list
-        list of matplotlib objects with the BDT output
-        distributions for each class
-
+    res: list of matplotlib.figure.Figure
+        Model output distributions for each class
     """
     class_labels = np.unique(data[1])
     n_classes = len(class_labels)
@@ -138,7 +139,8 @@ def plot_distr(list_of_df, column=None, figsize=None, bins=50, log=False, labels
         Example: ['dEdx', 'pT', 'ct']
 
     figsize: list
-        The size in inches of the figure to create. Uses the value in matplotlib.rcParams by default.
+        The size in inches of the figure to create. Uses the value in
+        matplotlib.rcParams by default.
 
     bins: int or sequence of scalars or str
         If bins is an int, it defines the number of equal-width
@@ -159,10 +161,8 @@ def plot_distr(list_of_df, column=None, figsize=None, bins=50, log=False, labels
 
     Output
     -----------------------------------------
-    axes
-        array of matplotlib axes with the distributions
-        of the features for each class
-
+    axes: numpy array of matplotlib.figure.Figure
+        Distributions of the features for each class
     """
 
     if column is not None:
@@ -215,10 +215,8 @@ def plot_corr(list_of_df, columns, labels=None, **kwds):
 
     Output
     ------------------------------------------------
-    list
-        list of matplotlib objects with the correlations
-        between the features for each class
-
+    fig: list of matplotlib.figure.Figure
+        Correlations between the features for each class
     """
 
     corr_mat = []
@@ -270,7 +268,7 @@ def plot_corr(list_of_df, columns, labels=None, **kwds):
 
 def plot_bdt_eff(threshold, eff_sig):
     """
-    Plot the BDT efficiency calculated with the function
+    Plot the model efficiency calculated with the function
     bdt_efficiency_array() in analysis_utils
 
     Input
@@ -279,14 +277,13 @@ def plot_bdt_eff(threshold, eff_sig):
         Score threshold array
 
     eff_sig: array
-        bdt efficiency array
+        model efficiency array
 
     Output
     -----------------------------------
-    matplotlib_obj
-        Plot containing bdt efficiency as a
+    res: matplotlib.figure.Figure
+        Plot containing model efficiency as a
         function of the threshold score
-
     """
     res = plt.figure()
     plt.plot(threshold, eff_sig, 'r.', label='Signal efficiency')
@@ -337,7 +334,7 @@ def plot_roc(y_truth, y_score, pos_label=None, labels=None, average='macro', mul
 
     Output
     -------------------------------------
-    matplotlib_obj
+    res: matplotlib.figure.Figure
         Plot containing the roc curves
     """
     # get number of classes
@@ -463,7 +460,7 @@ def plot_roc_train_test(y_truth_test, y_score_test, y_truth_train, y_score_train
 
     Output
     -------------------------------------
-    matplotlib_obj
+    res: matplotlib.figure.Figure
         Plot containing the roc curves
     """
     # call plot_roc for both train and test sets
@@ -534,9 +531,8 @@ def plot_feature_imp(df_in, y_truth, model, labels=None, n_sample=10000, approxi
 
     Output
     -------------------------------------------
-    list
-        list of matplotlib objects with shap feature importance
-
+    res: list of matplotlib.figure.Figure
+        Plots with shap feature importance
     """
     class_labels, class_counts = np.unique(y_truth, return_counts=True)
     n_classes = len(class_labels)
@@ -583,12 +579,10 @@ def plot_precision_recall(y_truth, y_score, labels=None, pos_label=None):
         if y_true is in {0, 1, ..., N}, pos_label is set to 1,
         otherwise an error will be raised.
 
-
     Output
     -------------------------------------
-    matplotlib_obj
+    res: matplotlib.figure.Figure
         Plot containing the precision recall curves
-
     """
     # get number of classes
     n_classes = len(np.unique(y_truth))
@@ -652,12 +646,10 @@ def plot_learning_curves(model, data, n_points=10):
     n_points: int
         Number of points used to sample the learning curves
 
-
     Output
     -------------------------------------
-    matplotlib_obj
+    res: matplotlib.figure.Figure
         Plot containing the learning curves
-
     """
 
     res = plt.figure()

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ SETUP = Setup(
     name="hipe4ml",
 
     # LAST-TAG is a placeholder. Automatically replaced at deploy time with the right tag
-    version="0.0.3",
+    version="0.0.4",
 
     description="Minimal heavy ion physics environment for Machine Learning",
 


### PR DESCRIPTION
This PR reworks ROC usage in the case of multi-classification. I tried to use scikit-learn [roc_auc_score](https://scikit-learn.org/stable/modules/generated/sklearn.metrics.roc_auc_score.html#sklearn.metrics.roc_auc_score) as much as possible. The extension of the ROC metric to the multi-class case has some nuances (see [here](https://github.com/scikit-learn/scikit-learn/pull/7663#issuecomment-327544404) and [here](https://github.com/scikit-learn/scikit-learn/pull/7663#issuecomment-307566895)), so I decided to stick with the scikit-learn approach that is based on published articles.

I also added a `multiclass` flag to the ModelHandler data members and cleaned the docstrings.