### PR TITLE
 Add output_margin option + bool for returning the predictions in train_test_data

### DIFF
--- a/hipe4ml/model_handler.py
+++ b/hipe4ml/model_handler.py
@@ -40,8 +40,7 @@ class ModelHandler:
         self._n_classes = None
 
         if self.model is not None:
-            self.model_string = inspect.getmodule(
-                self.model).__name__.partition('.')[0]
+            self.model_string = inspect.getmodule(self.model).__name__.partition('.')[0]
 
             if self.model_params is None:
                 self.model_params = self.model.get_params()
@@ -353,8 +352,7 @@ class ModelHandler:
             max_params[key] = optimizer.max['params'][key]
         print(f"Best target: {optimizer.max['target']:.6f}")
         print(f'Best parameters: {max_params}')
-        self.set_model_params(
-            {**self.model_params, **self.cast_model_params(max_params)})
+        self.set_model_params({**self.model_params, **self.cast_model_params(max_params)})
 
     def cast_model_params(self, params):
         """


### PR DESCRIPTION
I kept the output_margin default == False (unlike in the predict method) because the raw score is not supported in the roc_auc computation for multiclass