### PR TITLE
Load multiple files with TreeHandler

### DIFF
--- a/hipe4ml/tree_handler.py
+++ b/hipe4ml/tree_handler.py
@@ -39,13 +39,14 @@ class TreeHandler:
         """
         self._files = file_name if isinstance(file_name, list) else [file_name]
         self._tree = tree_name
-        df_list = list()
+        self._full_data_frame = pd.DataFrame()
         for file in self._files:
             if self._tree is not None:
-                df_list.append(uproot.open(file)[self._tree].pandas.df(branches=columns_names, **kwds))
+                self._full_data_frame = self._full_data_frame.append(
+                    uproot.open(file)[self._tree].pandas.df(branches=columns_names, **kwds), ignore_index=True)
             else:
-                df_list.append(pd.read_parquet(file, columns=columns_names, **kwds))
-        self._full_data_frame = pd.concat(df_list)
+                self._full_data_frame = self._full_data_frame.append(
+                    pd.read_parquet(file, columns=columns_names, **kwds), ignore_index=True)
         self._preselections = None
         self._projection_variable = None
         self._projection_binning = None

--- a/hipe4ml/tree_handler.py
+++ b/hipe4ml/tree_handler.py
@@ -21,12 +21,12 @@ class TreeHandler:
 
         Parameters
         ------------------------------------------------
-        file_name: str
-            Name of the input file where the data sit
+        file_name: str or list of str
+            Name of the input file where the data sit or list of input files
 
         tree_name: str
-            Name of the tree within the input file. If None the method pandas.read_parquet
-            is called
+            Name of the tree within the input file, must be the same for all files.
+            If None the method pandas.read_parquet is called
 
         columns_name: list
             List of the names of the branches that one wants to analyse. If columns_names is
@@ -37,14 +37,15 @@ class TreeHandler:
                 https://uproot.readthedocs.io/en/latest/opening-files.html#uproot-pandas-iterate
                 https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_parquet.html#pandas.read_parquet
         """
-        if tree_name is not None:
-            self._file = uproot.open(file_name)
-            self._tree = self._file[tree_name]
-            self._full_data_frame = self._tree.pandas.df(
-                branches=columns_names, **kwds)
-        else:
-            self._full_data_frame = pd.read_parquet(
-                file_name, columns=columns_names, **kwds)
+        self._files = file_name if isinstance(file_name, list) else [file_name]
+        self._tree = tree_name
+        df_list = list()
+        for file in self._files:
+            if self._tree is not None:
+                df_list.append(uproot.open(file)[self._tree].pandas.df(branches=columns_names, **kwds))
+            else:
+                df_list.append(pd.read_parquet(file, columns=columns_names, **kwds))
+        self._full_data_frame = pd.concat(df_list)
         self._preselections = None
         self._projection_variable = None
         self._projection_binning = None
@@ -368,7 +369,7 @@ class TreeHandler:
         Print information about the TreeHandler object and its
         data members
         """
-        print("\nFile name: ", self._file)
+        print("\nFile name: ", self._files)
         print("Tree name: ", self._tree)
         print("DataFrame head:\n", self._full_data_frame.head(5))
         print("\nPreselections:", self._preselections)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ scikit-learn>=0.22.1
 xgboost>=0.90,<1.0
 shap>=0.34
 bayesian-optimization>=1.0.1
+pyarrow>=0.17

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ SETUP = Setup(
     # installed. For an analysis of "install_requires" vs pip's requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=["uproot>=3.11.1", "matplotlib>=3.1.2", "pandas>=0.25.3", "scikit-learn>=0.22.1",
-                      "xgboost>=0.90,<1.0", "shap>=0.34", "bayesian-optimization>=1.0.1"],
+                      "xgboost>=0.90,<1.0", "shap>=0.34", "bayesian-optimization>=1.0.1", "pyarrow>=0.17"],
 
     python_requires=">=3.6",
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -64,9 +64,9 @@ def download_test_data(path):
     """
     data_url = 'https://raw.github.com/hipe4ml/hipe4ml_tests/master/Dplus7TeV/Bkg_Dpluspp7TeV_pT_1_50.root'
     prompt_url = 'https://raw.github.com/hipe4ml/hipe4ml_tests/master/Dplus7TeV/Prompt_Dpluspp7TeV_pT_1_50.root'
-    data_pq_url = ('https://raw.github.com/fcatalan92/hipe4ml_tests/master/Dplus7TeV/'
+    data_pq_url = ('https://raw.github.com/hipe4ml/hipe4ml_tests/master/Dplus7TeV/'
                    'Bkg_Dpluspp7TeV_pT_1_50.parquet.gzip')
-    prompt_pq_url = ('https://raw.github.com/fcatalan92/hipe4ml_tests/master/Dplus7TeV/'
+    prompt_pq_url = ('https://raw.github.com/hipe4ml/hipe4ml_tests/master/Dplus7TeV/'
                      'Prompt_Dpluspp7TeV_pT_1_50.parquet.gzip')
 
     urls = [data_url, prompt_url, data_pq_url, prompt_pq_url]

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -64,8 +64,12 @@ def download_test_data(path):
     """
     data_url = 'https://raw.github.com/hipe4ml/hipe4ml_tests/master/Dplus7TeV/Bkg_Dpluspp7TeV_pT_1_50.root'
     prompt_url = 'https://raw.github.com/hipe4ml/hipe4ml_tests/master/Dplus7TeV/Prompt_Dpluspp7TeV_pT_1_50.root'
+    data_pq_url = ('https://raw.github.com/fcatalan92/hipe4ml_tests/master/Dplus7TeV/'
+                   'Bkg_Dpluspp7TeV_pT_1_50.parquet.gzip')
+    prompt_pq_url = ('https://raw.github.com/fcatalan92/hipe4ml_tests/master/Dplus7TeV/'
+                     'Prompt_Dpluspp7TeV_pT_1_50.parquet.gzip')
 
-    urls = [data_url, prompt_url]
+    urls = [data_url, prompt_url, data_pq_url, prompt_pq_url]
 
     return download_from_url_list(urls, path)
 

--- a/tests/test_tree_handler.py
+++ b/tests/test_tree_handler.py
@@ -42,7 +42,7 @@ def terminate_tree_handler_test_workspace(path):
     print('Terminate test worksapce: done!')
 
 
-def test_tree_handler():
+def test_tree_handler():  # pylint: disable=too-many-statements
     """
     Test the TreeHandler class functionalities.
     """
@@ -55,6 +55,10 @@ def test_tree_handler():
     # instantiate tree handler objects
     data_hdlr = TreeHandler(test_data[0], 'treeMLDplus')
     prompt_hdlr = TreeHandler(test_data[1], 'treeMLDplus')
+    data_pq_hdlr = TreeHandler(test_data[2])
+    prompt_pq_hdlr = TreeHandler(test_data[3])
+    mult_hdlr = TreeHandler(test_data[:2], 'treeMLDplus')
+    mult_pq_hdlr = TreeHandler(test_data[2:])
 
     # open refernces objects
     reference_data_slice_df = pd.read_pickle(references[0])
@@ -63,6 +67,18 @@ def test_tree_handler():
         reference_dict = pickle.load(handle)
 
     terminate_tree_handler_test_workspace(test_dir)
+
+    # test that data is the same in root and parquet
+    assert data_hdlr.get_data_frame().equals(data_pq_hdlr.get_data_frame()), \
+        'data Dataframe from parquet file differs from the root file one!'
+    assert prompt_hdlr.get_data_frame().equals(prompt_pq_hdlr.get_data_frame()), \
+        'prompt Dataframe from parquet file differs from the root file one!'
+
+    # test loading from multiple files
+    merged_df = pd.concat([data_hdlr.get_data_frame(), prompt_hdlr.get_data_frame()])
+    assert mult_hdlr.get_data_frame().equals(merged_df), 'loading of multiple root files not working!'
+    merged_pq_df = pd.concat([data_pq_hdlr.get_data_frame(), prompt_pq_hdlr.get_data_frame()])
+    assert mult_pq_hdlr.get_data_frame().equals(merged_pq_df), 'loading of multiple parquet files not working!'
 
     # define the info dict that will be compared with the reference
     info_dict = {}
@@ -82,7 +98,7 @@ def test_tree_handler():
     data_hdlr.apply_preselections(preselections_data)
     prompt_hdlr.apply_preselections(preselections_prompt)
 
-    # get the number of selcted data
+    # get the number of selected data
     info_dict['n_data_preselected'] = data_hdlr.get_n_cand()
     info_dict['n_prompt_preselected'] = prompt_hdlr.get_n_cand()
 

--- a/tests/test_tree_handler.py
+++ b/tests/test_tree_handler.py
@@ -75,9 +75,9 @@ def test_tree_handler():  # pylint: disable=too-many-statements
         'prompt Dataframe from parquet file differs from the root file one!'
 
     # test loading from multiple files
-    merged_df = pd.concat([data_hdlr.get_data_frame(), prompt_hdlr.get_data_frame()])
+    merged_df = pd.concat([data_hdlr.get_data_frame(), prompt_hdlr.get_data_frame()], ignore_index=True)
     assert mult_hdlr.get_data_frame().equals(merged_df), 'loading of multiple root files not working!'
-    merged_pq_df = pd.concat([data_pq_hdlr.get_data_frame(), prompt_pq_hdlr.get_data_frame()])
+    merged_pq_df = pd.concat([data_pq_hdlr.get_data_frame(), prompt_pq_hdlr.get_data_frame()], ignore_index=True)
     assert mult_pq_hdlr.get_data_frame().equals(merged_pq_df), 'loading of multiple parquet files not working!'
 
     # define the info dict that will be compared with the reference


### PR DESCRIPTION
@fmazzasc What do you think? 
I didn't use https://uproot.readthedocs.io/en/latest/opening-files.html#uproot-pandas-iterate because it does not maintain the same order of the data. However, this probably is an issue only for the tests.

Fix #84.

- [x] To be merged after hipe4ml/hipe4ml_tests#3 and after updating the URL of the new files.