### PR TITLE
Drop py3.6 tests in CI matrices

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 6
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8]
         test-tool: [pylint, flake8, pytest]
 
     steps:
@@ -39,7 +39,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8]
         test-tool: [pylint, flake8, pytest]
 
     steps:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-uproot>=3.13.1
+uproot==3.13.1
 matplotlib>=3.3.3
 pandas>=1.1.4
 scikit-learn>=0.23.2


### PR DESCRIPTION
We are going to drop python 3.6 support because of its incompatibilities
with shap requirements (latest Numpy).