### PR TITLE
Temporary fix for hipe4ml tutorial

### DIFF
--- a/tutorials/hipe4ml_tutorial_binary.ipynb
+++ b/tutorials/hipe4ml_tutorial_binary.ipynb
@@ -54,6 +54,24 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### **Restart Runtime(temporary)** \n",
+    "Due to a conflict with the Colab pre-installed matplotlib package, it is required to restart the runtime before running the notebook. Restart the runtime with the command below and then go directly to the **File Download** section. Do not run the following cell if you are running the notebook in your local machine"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "os.kill(os.getpid(), 9)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "colab_type": "text",
     "id": "tF_PTv-FW9TX"
@@ -271,7 +289,7 @@
     "\n",
     "In the cross validation procedure, the original sample is divided in _n_ parts called _folds_ (in this case 5 folds are used). For each set of hyperparameters, _n-1_ folds are used for the optimisation and the remaining one as test. This operation is repeated after permuting the folds used for optimisation and for testing and the final result is the mean value of all the permutations.\n",
     "\n",
-    "The ModelHandler automatically updates the hyperparemeters after their optimisation.\n",
+    "The ModelHandler automatically updates the hyperparameters after their optimisation.\n",
     "\n"
    ]
   },
@@ -358,7 +376,7 @@
    "source": [
     "The results of the training process can be observed by plotting the distributions of the BDT score for the training and the test sets. This operation is performed with the method _plot\\_utils_._plot\\_output\\_train\\_test_.\n",
     "\n",
-    "The distributions of the model scores obtained from the test set are in good agreement with those obtained from the training set. This is a sign that tha model has been treined properly.\n",
+    "The distributions of the model scores obtained from the test set are in good agreement with those obtained from the training set. This is a sign that tha model has been trained properly.\n",
     "\n",
     "A disagreement between the distributions obtained from the training set and the datasets would reflect an overfitting by the classification algorithm: the classifier has learnt some characteristics that are peculiar of the training set but that are not true for a general sample."
    ]


### PR DESCRIPTION
Due to a conflict with the Colab pre-installed packages the tutorial crashes when importing matplotlib. This fix forces the user to restart the runtime after the external packages installation. After the restart everything seems to work as usual. Since I haven't found a smarter solution to avoid the crash I purpose to merge this temporary fix for the moment. Then we should try to address the issue in a more definitive way, maybe considering to move to Binder or another Jupyter Notebook cloud provider.