### PR TITLE
Add python 3.6 support back

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 6
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8]
         test-tool: [pylint, flake8, pytest]
 
     steps:
@@ -20,6 +20,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          pip install --upgrade setuptools
           pip install -r requirements.txt
       - name: Test with ${{ matrix.test-tool }}
         run: |
@@ -39,7 +40,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8]
         test-tool: [pylint, flake8, pytest]
 
     steps:
@@ -52,6 +53,7 @@ jobs:
         run: |
           brew install libomp
           python -m pip install --upgrade pip
+          pip install --upgrade setuptools
           pip install -r requirements.txt
       - name: Test with ${{ matrix.test-tool }}
         run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 uproot==3.13.1
 matplotlib>=3.3.4
-pandas>=1.2.2
+pandas==1.1.5
 scikit-learn>=0.24.1
 xgboost==1.3.3
 shap==0.38.1
 bayesian-optimization==1.2.0
 pyarrow==3.0.0
-ipython==7.20.0
+ipython==7.16.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ matplotlib>=3.3.3
 pandas>=1.1.4
 scikit-learn>=0.23.2
 xgboost>=1.2.1
-shap>=0.37
+shap>=0.38.1
 bayesian-optimization>=1.2
 pyarrow>=2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-ipython>=6.0.0
 uproot==3.13.1
-matplotlib>=3.3.3
-pandas>=1.1.4
-scikit-learn>=0.23.2
-xgboost>=1.2.1
-shap>=0.38.1
-bayesian-optimization>=1.2
-pyarrow>=2.0
+matplotlib>=3.3.4
+pandas>=1.2.2
+scikit-learn>=0.24.1
+xgboost==1.3.3
+shap==0.38.1
+bayesian-optimization==1.2.0
+pyarrow==3.0.0
+ipython==7.20.0

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ import os.path
 from setuptools import setup, find_packages
 
 
-class Setup(object):
+class Setup():
     """Convenience wrapper (for C.I. purposes) of the `setup()` call form `setuptools`.
     """
     def __init__(self, **kw):

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ SETUP = Setup(
         "Intended Audience :: Developers",
         "Topic :: Scientific/Engineering :: Physics",
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8"
     ],
@@ -84,15 +85,16 @@ SETUP = Setup(
     # installed. For an analysis of "install_requires" vs pip's requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=["uproot==3.13.1", "matplotlib>=3.3.3", "pandas>=1.1.4", "scikit-learn>=0.23.2",
-                      "xgboost>=1.2.1", "shap>=0.37", "bayesian-optimization>=1.2", "pyarrow>=2.0"],
+                      "xgboost>=1.2.1", "shap>=0.38.1", "bayesian-optimization>=1.2", "pyarrow>=2.0",
+                      "ipython>=6.0.0"],
 
-    python_requires=">=3.7",
+    python_requires=">=3.6",
 
     # List additional groups of dependencies here (e.g. development dependencies). You can install
     # these using the following syntax, for example:
     # $ pip install -e .[dev,test]
     extras_require={
-        "dev": ["pylint>=2.4.4", "flake8>=3.7.9", "pytest>=5.3.4", "twine>=1.11.0", "setuptools>=38.6.0",
+        "dev": ["pylint>=2.4.4", "flake8>=3.7.9", "pytest>=5.3.4", "twine>=1.11.0", "setuptools>=53.0.0",
                 "wheel>=0.31.0"]
     },
 

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ SETUP = Setup(
     # these using the following syntax, for example:
     # $ pip install -e .[dev,test]
     extras_require={
-        "dev": ["pylint==2.6.0", "flake8>=3.8.4", "pytest>=6.2.2", "twine>=3.3.0", "setuptools==53.0.0",
+        "dev": ["pylint>=2.6.2", "flake8>=3.8.4", "pytest>=6.2.2", "twine>=3.3.0", "setuptools==53.0.0",
                 "wheel>=0.36.2"]
     },
 

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ SETUP = Setup(
     # these using the following syntax, for example:
     # $ pip install -e .[dev,test]
     extras_require={
-        "dev": ["pylint>=2.6.1", "flake8>=3.8.4", "pytest>=6.2.2", "twine>=3.3.0", "setuptools==53.0.0",
+        "dev": ["pylint==2.6.0", "flake8>=3.8.4", "pytest>=6.2.2", "twine>=3.3.0", "setuptools==53.0.0",
                 "wheel>=0.36.2"]
     },
 

--- a/setup.py
+++ b/setup.py
@@ -84,9 +84,9 @@ SETUP = Setup(
     # List run-time dependencies here. These will be installed by pip when your project is
     # installed. For an analysis of "install_requires" vs pip's requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=["uproot==3.13.1", "matplotlib>=3.3.4", "pandas>=1.2.2", "scikit-learn>=0.24.1",
+    install_requires=["uproot==3.13.1", "matplotlib>=3.3.4", "pandas==1.1.5", "scikit-learn>=0.24.1",
                       "xgboost==1.3.3", "shap==0.38.1", "bayesian-optimization==1.2.0", "pyarrow==3.0.0",
-                      "ipython==7.20.0"],
+                      "ipython==7.16.1"],
 
     python_requires=">=3.6",
 

--- a/setup.py
+++ b/setup.py
@@ -84,9 +84,9 @@ SETUP = Setup(
     # List run-time dependencies here. These will be installed by pip when your project is
     # installed. For an analysis of "install_requires" vs pip's requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=["uproot==3.13.1", "matplotlib>=3.3.3", "pandas>=1.1.4", "scikit-learn>=0.23.2",
-                      "xgboost>=1.2.1", "shap>=0.38.1", "bayesian-optimization>=1.2", "pyarrow>=2.0",
-                      "ipython>=6.0.0"],
+    install_requires=["uproot==3.13.1", "matplotlib>=3.3.4", "pandas>=1.2.2", "scikit-learn>=0.24.1",
+                      "xgboost==1.3.3", "shap==0.38.1", "bayesian-optimization==1.2.0", "pyarrow==3.0.0",
+                      "ipython==7.20.0"],
 
     python_requires=">=3.6",
 
@@ -94,8 +94,8 @@ SETUP = Setup(
     # these using the following syntax, for example:
     # $ pip install -e .[dev,test]
     extras_require={
-        "dev": ["pylint>=2.4.4", "flake8>=3.7.9", "pytest>=5.3.4", "twine>=1.11.0", "setuptools>=53.0.0",
-                "wheel>=0.31.0"]
+        "dev": ["pylint>=2.6.1", "flake8>=3.8.4", "pytest>=6.2.2", "twine>=3.3.0", "setuptools==53.0.0",
+                "wheel>=0.36.2"]
     },
 
     # Although 'package_data' is the preferred approach, in some case you may need to place data


### PR DESCRIPTION
Turns out that having support for python 3.6 is nice (especially if you are using CentOS7). It looks possible now.