### PR TITLE
Fix for ipython dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ shap==0.38.1
 bayesian-optimization==1.2.0
 pyarrow==3.0.0
 ipython==7.16.1
+jedi==0.17.2

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ SETUP = Setup(
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=["uproot==3.13.1", "matplotlib>=3.3.4", "pandas==1.1.5", "scikit-learn>=0.24.1",
                       "xgboost==1.3.3", "shap==0.38.1", "bayesian-optimization==1.2.0", "pyarrow==3.0.0",
-                      "ipython==7.16.1"],
+                      "ipython==7.16.1", "jedi==0.17.2"],
 
     python_requires=">=3.6",
 


### PR DESCRIPTION
Pinning `jedi` version to fix an incompatibility with `ipython` supporting python 3.6 https://github.com/ipython/ipython/issues/12821