### PR TITLE
Update Python versions in CI

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9]
         test-tool: [pylint, flake8, pytest]
 
     steps:


### PR DESCRIPTION
- Remove 3.6 on macos
- Let's see if 3.9 creates some problems