### PR TITLE
Fix ModelHandler dump to pickle

### DIFF
--- a/hipe4ml/model_handler.py
+++ b/hipe4ml/model_handler.py
@@ -430,7 +430,7 @@ class ModelHandler:
             Name of the file in which the model is saved
         """
         with open(filename, "wb") as output_file:
-            pickle.dump(self.model, output_file)
+            pickle.dump(self, output_file)
 
     def load_model_handler(self, filename):
         """


### PR DESCRIPTION
@mpuccio, @mconcas PR #127 introduced a bug in dumping the ModelHandler to pickle. Thanks to @cterrevo for spotting this.

![Screenshot from 2021-10-26 14-26-35](https://user-images.githubusercontent.com/11328262/138879896-36b336cb-2991-4273-acc9-5fa0af3644db.png)

I think that this hotfix should be merged and propagated to master + new release even if the CI is currently not working.