### PR TITLE
Fix bug in dump_model_handler

### DIFF
--- a/hipe4ml/model_handler.py
+++ b/hipe4ml/model_handler.py
@@ -430,7 +430,7 @@ class ModelHandler:
             Name of the file in which the model is saved
         """
         with open(filename, "wb") as output_file:
-            pickle.dump(self.model, output_file)
+            pickle.dump(self, output_file)
 
     def load_model_handler(self, filename):
         """


### PR DESCRIPTION
Fixed bug in "dump_model_handler" method that dumps only the model and not the whole object.