### PR TITLE
Add possibility to dump models in .onnx and convert them in tensor format with hummingbird

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -55,6 +55,7 @@ jobs:
           brew install libomp
           python -m pip install --upgrade pip
           pip install --upgrade setuptools
+          pip install wheel
           pip install -r requirements.txt
       - name: Test with ${{ matrix.test-tool }}
         run: |

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -21,6 +21,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install --upgrade setuptools
+          pip install wheel
           pip install -r requirements.txt
       - name: Test with ${{ matrix.test-tool }}
         run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,7 @@ bayesian-optimization==1.2.0
 pyarrow>=5.0.0
 ipython>=7.16.1
 jedi==0.17.2
+torch>=1.6.0
+onnx==1.8.0
+onnxruntime==1.7.0
+hummingbird_ml[extra]>=0.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,6 @@ ipython>=7.16.1
 jedi==0.17.2
 torch>=1.6.0
 onnx==1.8.0
+onnxmltools==1.7.0
 onnxruntime==1.7.0
 hummingbird_ml[extra]>=0.4.2

--- a/setup.py
+++ b/setup.py
@@ -86,8 +86,8 @@ SETUP = Setup(
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=["uproot>=4.1.5", "matplotlib>=3.3.4", "pandas>=1.1.5", "scikit-learn>=0.24.1",
                       "xgboost>=1.4.2", "shap==0.38.1", "bayesian-optimization==1.2.0", "pyarrow>=5.0.0",
-                      "ipython>=7.16.1", "jedi==0.17.2", "torch>=1.6.0", "onnx==1.8.0", "onnxruntime==1.7.0",
-                      "hummingbird_ml[extra]>=0.4.2"],
+                      "ipython>=7.16.1", "jedi==0.17.2", "torch>=1.6.0", "onnx==1.8.0", "onnxmltools==1.7.0",
+                      "onnxruntime==1.7.0", "hummingbird_ml[extra]>=0.4.2"],
 
     python_requires=">=3.7",
 

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,8 @@ SETUP = Setup(
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=["uproot>=4.1.5", "matplotlib>=3.3.4", "pandas>=1.1.5", "scikit-learn>=0.24.1",
                       "xgboost>=1.4.2", "shap==0.38.1", "bayesian-optimization==1.2.0", "pyarrow>=5.0.0",
-                      "ipython>=7.16.1", "jedi==0.17.2"],
+                      "ipython>=7.16.1", "jedi==0.17.2", "torch>=1.6.0", "onnx==1.8.0", "onnxruntime==1.7.0",
+                      "hummingbird_ml[extra]>=0.4.2"],
 
     python_requires=">=3.7",
 

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -11,6 +11,7 @@ function perr() { echo -e "\033[31m${1}\033[m" >&2; }
 
 setup-hipe4ml() {
     pinfo "installing: hipe4ml"
+    pip3 install wheel
     pip3 install --upgrade --force-reinstall --no-deps -e .
 }
 

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -11,7 +11,6 @@ function perr() { echo -e "\033[31m${1}\033[m" >&2; }
 
 setup-hipe4ml() {
     pinfo "installing: hipe4ml"
-    pip3 install wheel
     pip3 install --upgrade --force-reinstall --no-deps -e .
 }
 


### PR DESCRIPTION
This PR adds 2 methods to the `model_handler.py` needed to dump the trained model to `.onnx` format and to convert it to a tensor format (`ONNX`, `PyTorch`, `TorchScript` or `TMV`) before dumping it. The `onnx` and `onnxruntime` libraries have fixed versions to match the one used in [O2Physics](https://github.com/AliceO2Group/O2Physics).