### PR TITLE
Update supported python versions

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 6
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9, 3.10.x, 3.11.x]
         test-tool: [pylint, flake8, pytest]
 
     steps:
@@ -40,7 +40,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9, 3.10.x, 3.11.x]
         test-tool: [pytest]
 
     steps:

--- a/setup.py
+++ b/setup.py
@@ -69,9 +69,10 @@ SETUP = Setup(
         "Intended Audience :: Developers",
         "Topic :: Scientific/Engineering :: Physics",
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9"
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11"
     ],
 
     # What does your project relate to?
@@ -88,7 +89,7 @@ SETUP = Setup(
                       "xgboost>=1.5.2,<2.0", "lightgbm>=3.3.2", "shap==0.42.1", "pyarrow>=7.0.0",
                       "ipython>=7.32.0", "optuna>=2.10.0", "numpy<1.25"],
 
-    python_requires=">=3.7",
+    python_requires=">=3.8",
 
     # List additional groups of dependencies here (e.g. development dependencies). You can install
     # these using the following syntax, for example:


### PR DESCRIPTION
Remove python3.7 which is at the end of life (https://devguide.python.org/versions/) and add python3.10 and python3.11.
To be rebased on https://github.com/hipe4ml/hipe4ml/pull/158