### PR TITLE
Fix shap feature importance plot

### DIFF
--- a/hipe4ml/plot_utils.py
+++ b/hipe4ml/plot_utils.py
@@ -607,7 +607,8 @@ def plot_feature_imp(df_in, y_truth, model, labels=None, n_sample=10000, approxi
     else:
         for i_class in range(n_classes):
             res.append(plt.figure(figsize=(18, 9)))
-            shap.summary_plot(shap_values[i_class], df_subs, plot_size=(
+            shap_values_transposed = shap_values.transpose(1, 0, 2)
+            shap.summary_plot(shap_values_transposed[i_class], df_subs, plot_size=(
                 18, 9), class_names=labels, show=False)
 
     res.append(plt.figure(figsize=(18, 9)))


### PR DESCRIPTION
This PR fixes a bug in the feature importance plotting function for multi-class classification.
In fact, since shap `v0.43.1` the behaviour of `TreeExplainer` has changed, causing a crash of the feature importance plotting function:

```
---------------------------------------------------------------------------

AssertionError                            Traceback (most recent call last)

[<ipython-input-13-5ef1aad04c05>](https://localhost:8080/#) in <cell line: 1>()
----> 1 plot_utils.plot_feature_imp(train_test_data[2][features_for_train], train_test_data[3], model_hdl, leg_labels)

1 frames

[/usr/local/lib/python3.10/dist-packages/shap/plots/_beeswarm.py](https://localhost:8080/#) in summary_legacy(shap_values, features, feature_names, max_display, plot_type, color, axis_color, title, alpha, show, sort, color_bar, plot_size, layered_violin_max_num_bins, class_names, class_inds, color_bar_label, cmap, show_values_in_legend, use_log_scale)
    541                           "constant offset? Of so just pass shap_values[:,:-1]."
    542         else:
--> 543             assert num_features == features.shape[1], shape_msg
    544 
    545     if feature_names is None:

AssertionError: The shape of the shap_values matrix does not match the shape of the provided data matrix.

<Figure size 1800x900 with 0 Axes>
```