### PR TITLE
Fix loading of trees from multiple directories in case of multiple cycles

### DIFF
--- a/hipe4ml/tree_handler.py
+++ b/hipe4ml/tree_handler.py
@@ -77,6 +77,13 @@ class TreeHandler:
                 continue
 
             file_folders = uproot.open(file).keys()
+            # check if there are multiple cycles of the same tree, keep only last one
+            # first we sort to have as first one the last cycle
+            file_folders.sort(reverse=True)
+            for ifolder, folder in enumerate(file_folders[1:]):
+                obj_nocycle = folder.split(";")[0]
+                if obj_nocycle in file_folders[ifolder]:
+                    file_folders.remove(folder)
             tree_path_list = []
             for folder in file_folders:
                 if folder_name[:-1] in folder and self._tree in folder:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 uproot>=4.2.2
 matplotlib>=3.5.1
 pandas>=1.3.5
-scikit-learn>=1.0.2
+scikit-learn>=1.0.2,<1.6
 xgboost>=1.5.2,<2.0
 lightgbm>=3.3.2
 shap>=0.45

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ SETUP = Setup(
     # List run-time dependencies here. These will be installed by pip when your project is
     # installed. For an analysis of "install_requires" vs pip's requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=["uproot>=4.2.2", "matplotlib>=3.5.1", "pandas>=1.3.5", "scikit-learn>=1.0.2",
+    install_requires=["uproot>=4.2.2", "matplotlib>=3.5.1", "pandas>=1.3.5", "scikit-learn>=1.0.2,<1.6",
                       "xgboost>=1.5.2,<2.0", "lightgbm>=3.3.2", "shap>=0.45", "pyarrow>=7.0.0",
                       "ipython>=7.32.0", "optuna>=2.10.0", "numpy>=1.26"],
 


### PR DESCRIPTION
In case the feature to load trees from multiple directories (i.e. `DF*`), if there are multiple cycles of the same object in the `ROOT` file as in this example

<img width="225" alt="image" src="https://github.com/user-attachments/assets/9db81904-ff58-4122-aae3-9f2162e8a46c" />

The data are loaded multiple times (one for each cycle), implying data duplication:
```
Reading Tree_train_merged.root:DF_2366977983152787/O2hfredcandb0lite;2
Reading Tree_train_merged.root:DF_2366977983152787/O2hfredcandb0lite;1
```

This PR fixes this issue, by keeping only the last cycle:
```
Reading Tree_train_merged.root:DF_2366977983152787/O2hfredcandb0lite;2
```

PS: I also had to add a limit to the `scikit-learn` version due to [this](https://stackoverflow.com/questions/79290968/super-object-has-no-attribute-sklearn-tags)