### PR TITLE
Fix optuna FutureWarning

### DIFF
--- a/hipe4ml/model_handler.py
+++ b/hipe4ml/model_handler.py
@@ -377,7 +377,7 @@ class ModelHandler:
 
         x_train, y_train, _, _ = data
 
-        def __get_int_or_uniform(hyperparams_ranges, trial):
+        def __get_int_or_float(hyperparams_ranges, trial):
 
             params = {}
 
@@ -386,14 +386,14 @@ class ModelHandler:
                     params[key] = trial.suggest_int(
                         key, hyperparams_ranges[key][0], hyperparams_ranges[key][1])
                 elif isinstance(hyperparams_ranges[key][0], float):
-                    params[key] = trial.suggest_uniform(
+                    params[key] = trial.suggest_float(
                         key, hyperparams_ranges[key][0], hyperparams_ranges[key][1])
 
             return params
 
         def __objective(trial):
 
-            params = __get_int_or_uniform(hyperparams_ranges, trial)
+            params = __get_int_or_float(hyperparams_ranges, trial)
             model_copy = deepcopy(self.model)
             model_copy.set_params(**{**self.model_params, **params})
             return np.mean(cross_val_score(model_copy, x_train[self.training_columns], y_train,


### PR DESCRIPTION
Since optuna v3.0.0 `suggest_uniform` is deprecated in favor of `suggest_float`, the behavior is unchanged since `suggest_float` was already used behind the scenes in v3.0.0