### PR TITLE
Improve docstring rendering

### DIFF
--- a/hipe4ml/tree_handler.py
+++ b/hipe4ml/tree_handler.py
@@ -36,9 +36,9 @@ class TreeHandler:
             not specified all the branches are converted
 
         folder_name: str
-            Name of the folder/folders within the input file. If the folder_name ends with a '*' all the folders
+            Name of the folder/folders within the input file. If the folder_name ends with a `"*"` all the folders
             containing the string folder_name are read and merged into a single dataframe.
-            Example: folder_name = "DF*" will read all the folders containing the string "DF" and
+            Example: `folder_name = "DF*"` will read all the folders containing the string `"DF"` and
             merge them into a single dataframe.
 
         **kwds: extra arguments are passed on to the uproot.TTree.arrays() or pandas.read_parquet() methods:


### PR DESCRIPTION
add backticks code blocks to docstring to prevent asterisks being interpreted as markdown italics

Currently, VS Code interprets asterisks in the docstring as markdown, which is very confusing. It can easily be interpreted as though `folder_name` parameter was looking for a substring in folder names by default, instead of globbing with an asterisk.

Adding markdown inline code blocks fixes this, with minimal impact on the interpretation of plaintext.

Before:
<img width="563" height="122" alt="image" src="https://github.com/user-attachments/assets/7544edc0-5851-48ce-ac3d-7ec9ff151e78" />

After:
<img width="480" height="125" alt="image" src="https://github.com/user-attachments/assets/0c610fad-16af-4707-b5d4-44efaa7e4788" />
